### PR TITLE
Fix d'une faille de sécurité dans generatejson.php

### DIFF
--- a/generatejson.php
+++ b/generatejson.php
@@ -5,9 +5,7 @@ $idSite = $_GET['id_site'];
 $view = $_GET['view'];
 header('Content-type: application/json');
 
-$query = "SELECT * FROM ".$view." WHERE id_site = '".$idSite."'";
-$rs = pg_query($dbconnect, $query) or die("La requete suivante ne peut pas etre executee : $query\n");
-
+$rs = pg_query_params($dbconnect, "SELECT * FROM " . pg_escape_string($view). " WHERE id_site = $1" , array($idSite)) or die("La requete suivante ne peut pas etre executee : $query\n");
 //Construction du GeoJSON
 $json = array();
 


### PR DESCRIPTION
La requête SQL était initialement construite à partir des paramètres GET de la requête http, sans vérification aucune.
-> Utilisation des fonctions pg_escape_string pour la vue et pg_query_params pour pour l'idSite pour échapper les quelconques caractères permettant une injection SQL.
